### PR TITLE
Update zenity-box.sh

### DIFF
--- a/scripts-arch/zenity-box.sh
+++ b/scripts-arch/zenity-box.sh
@@ -27,7 +27,7 @@ if [[ $1 == bri* ]]; then
     fi
 
 elif [[ $1 == vol* ]]; then
-    lvl=$(amixer sget Master | grep 'Right:' | awk -F'[][]' '{ print $2 }')
+    lvl=$(amixer sget Master | grep '%' | awk -F'[][]' '{ print $2 }')
     lvl=${lvl::-1}
     lvl=$(rof -P zenity zenity --scale --value ${lvl} --title "Volume" --text "Set master volume level")
     if [[ ${lvl} ]]; then


### PR DESCRIPTION
In some case the Master channel have Mono as Playback channel.
For exemple this is the output of 'amixer sget Master' on my Lenovo b590:
Simple mixer control 'Master',0
  Capabilities: pvolume pvolume-joined pswitch pswitch-joined
  Playback channels: Mono
  Limits: Playback 0 - 87
  Mono: Playback 76 [87%] [-8.25dB] [on]

This change should be universal, whathever could be the Playback channel.